### PR TITLE
Added clipboard functionality to jobsearch

### DIFF
--- a/website/myapp/views/jobsearch.ejs
+++ b/website/myapp/views/jobsearch.ejs
@@ -1,312 +1,301 @@
 <%- include('partials/header'); -%>
 
-<div class="cover-container d-flex h-100 p-5 mx-auto flex-column text-center">
-  <main role="main" class="inner cover">
-    <div class="input-group rounded">
-      <form class="d-flex mx-auto" id="searchBar">
-        <input
-          class="form-control me-2"
-          id="userInput"
-          autocomplete="off"
-          placeholder="Search for a job"
-          aria-label="Search"
-        />
-        <select
-          class="form-select form-select-sm me-2"
-          style="width: auto"
-          aria-label=".form-select-sm"
-          id="location-selection"
-        >
-          <option selected>All Locations</option>
-          <option value="Your Location">Your Location</option>
-          <option value="Auckland">Auckland</option>
-          <option value="Wellington">Wellington</option>
-          <option value="Christchurch">Christchurch</option>
-          <option value="Dunedin">Dunedin</option>
-        </select>
+  <div class="cover-container d-flex h-100 p-5 mx-auto flex-column text-center">
+    <main role="main" class="inner cover">
+      <div class="input-group rounded">
+        <form class="d-flex mx-auto" id="searchBar">
+          <input class="form-control me-2" id="userInput" autocomplete="off" placeholder="Search for a job"
+            aria-label="Search" />
+          <select class="form-select form-select-sm me-2" style="width: auto" aria-label=".form-select-sm"
+            id="location-selection">
+            <option selected>All Locations</option>
+            <option value="Your Location">Your Location</option>
+            <option value="Auckland">Auckland</option>
+            <option value="Wellington">Wellington</option>
+            <option value="Christchurch">Christchurch</option>
+            <option value="Dunedin">Dunedin</option>
+          </select>
 
-        <select
-          class="form-select form-select-sm me-2"
-          style="width: auto"
-          aria-label=".form-select-sm"
-          id="category-selection"
-        >
-          <option selected>All Categories</option>
-          <option value="Junior">Junior</option>
-          <option value="Intermediate">Intermediate</option>
-          <option value="Senior">Senior</option>
-          <option value="Internship">Internship</option>
-        </select>
-        <button class="btn btn-primary" type="submit" id="searchButton">
-          Search
-        </button>
-      </form>
-    </div>
-  </main>
-  <div id="locationDisplay"></div>
-</div>
-<div class="cover-container d-flex mx-auto flex-column text-center">
-  <p id="resultsFound" class="text-muted"></p>
-</div>
-<div id="results" class=""></div>
-<div class="cover-container d-flex h-100 p-5 mx-auto flex-column text-center">
-  <div id="pages"></div>
-</div>
+          <select class="form-select form-select-sm me-2" style="width: auto" aria-label=".form-select-sm"
+            id="category-selection">
+            <option selected>All Categories</option>
+            <option value="Junior">Junior</option>
+            <option value="Intermediate">Intermediate</option>
+            <option value="Senior">Senior</option>
+            <option value="Internship">Internship</option>
+          </select>
+          <button class="btn btn-primary" type="submit" id="searchButton">
+            Search
+          </button>
+        </form>
+      </div>
+    </main>
+    <div id="locationDisplay"></div>
+  </div>
+  <div class="cover-container d-flex mx-auto flex-column text-center">
+    <p id="resultsFound" class="text-muted"></p>
+  </div>
+  <div id="results" class=""></div>
+  <div class="cover-container d-flex h-100 p-5 mx-auto flex-column text-center">
+    <div id="pages"></div>
+  </div>
 
-<script>
-  //Manages job listings
-  let jobs = ''
-  let searchString = ''
-  let locationSelection = ''
-  let categorySelection = ''
-  let defaultPage = 0
 
-  //Checks URL for search terms and reloads the page with search terms if any
-  checkURL()
+  <script>
+    //Manages job listings
+    let jobs = ''
+    let searchString = ''
+    let locationSelection = ''
+    let categorySelection = ''
+    let defaultPage = 0
+    let loadModal = ''
 
-  document
-    .getElementById('searchBar')
-    .addEventListener('submit', userAction, false)
+    //Checks URL for search terms and reloads the page with search terms if any
+    checkURL()
 
-  // Prevents page from reloading upon form submission
-  let form = document.getElementById('searchBar')
-  function handleForm(event) {
-    event.preventDefault()
-  }
-  form.addEventListener('submit', handleForm)
+    document
+      .getElementById('searchBar')
+      .addEventListener('submit', userAction, false)
 
-  // Collects users terms from the search bar and drop-down menu's and returns a job list
-  function userAction() {
-    document.getElementById('pages').innerHTML = ''
-    document.getElementById('resultsFound').innerHTML = ''
-    locationSelection = document.getElementById('location-selection')
-    categorySelection = document.getElementById('category-selection')
-    searchString = document.getElementById('userInput').value
+    // Prevents page from reloading upon form submission
+    let form = document.getElementById('searchBar')
+    function handleForm(event) {
+      event.preventDefault()
+    }
+    form.addEventListener('submit', handleForm)
 
-    let locationSelectionText =
-      locationSelection.options[locationSelection.selectedIndex].text
+    // Collects users terms from the search bar and drop-down menu's and returns a job list
+    function userAction() {
+      document.getElementById('pages').innerHTML = ''
+      document.getElementById('resultsFound').innerHTML = ''
+      locationSelection = document.getElementById('location-selection')
+      categorySelection = document.getElementById('category-selection')
+      searchString = document.getElementById('userInput').value
 
-    // Fetches users location data and returns the city name
-    let fetchedCity = fetch('https://geolocation-db.com/json/')
-      .then(function (res) {
-        if (!res.ok) {
-          throw Error(res.statusText)
-          return 'Unable to find your location'
+      let locationSelectionText =
+        locationSelection.options[locationSelection.selectedIndex].text
+
+      // Fetches users location data and returns the city name
+      let fetchedCity = fetch('https://geolocation-db.com/json/')
+        .then(function (res) {
+          if (!res.ok) {
+            throw Error(res.statusText)
+            return 'Unable to find your location'
+            document.getElementById('locationDisplay').innerHTML =
+              'Unable to find your location'
+          }
+          return res.json()
+        })
+        .then(function (locationData) {
+          let cityName = locationData.city
+          return cityName
+        })
+
+      if (locationSelectionText == 'Your Location') {
+        fetchedCity.then(function (result) {
+          locationSelectionText = result
           document.getElementById('locationDisplay').innerHTML =
-            'Unable to find your location'
-        }
-        return res.json()
-      })
-      .then(function (locationData) {
-        let cityName = locationData.city
-        return cityName
-      })
-
-    if (locationSelectionText == 'Your Location') {
-      fetchedCity.then(function (result) {
-        locationSelectionText = result
-        document.getElementById('locationDisplay').innerHTML =
-          'Detected Location: ' + result
-      })
-    }
-
-    if (locationSelectionText == 'All Locations') {
-      locationSelectionText = ''
-    }
-
-    let categorySelectionText =
-      categorySelection.options[categorySelection.selectedIndex].text
-
-    if (categorySelectionText == 'All Categories') {
-      categorySelectionText = ''
-    }
-
-    let jobText = ''
-
-    // Build search URL + call the buildJobList method on JSON results if they are valid and displays jobs via 'results'
-    generateSearchResults()
-
-    async function generateSearchResults() {
-      // Makes sure city data is fetched prior to commencing method
-      const cityDelay = await fetch('https://geolocation-db.com/json/')
-
-      let webhook_url =
-        'https://ap-southeast-2.aws.webhooks.mongodb-realm.com/api/client/v2.0/app/jobsearchapp-wfuox/service/jobs/incoming_webhook/getJobs'
-
-      // Appends the relevant search terms to the webhook to access search data
-      let url =
-        webhook_url +
-        '?arg=' +
-        searchString +
-        '&location=' +
-        locationSelectionText +
-        '&category=' +
-        categorySelectionText
-
-      fetch(url)
-        .then(function (response) {
-          if (!response.ok) {
-            console.log(response)
-            jobText += `<center><h3>Status: ${response.status}</h3></center>`
-            if (response.json.length === 0)
-              jobText += `<center><p>Please enter a search term.</p></center>`
-            document.getElementById('results').innerHTML = jobText
-            throw Error(response.statusText)
-          }
-          return response.json()
+            'Detected Location: ' + result
         })
-        .then(function (jobJSON) {
-          if (jobJSON['$undefined'] === true) {
-            console.log('No results fetched.')
-          } else {
-            console.log('Results fetched...')
-            if (jobJSON.length !== 0) {
-              jobText = ' jobs found.'
-              if (jobJSON.length == 1) {
-                jobText = ' job found.'
-              }
-              console.log('Search results found: ' + jobJSON.length)
-              document.getElementById('resultsFound').innerHTML =
-                jobJSON.length + jobText
-              jobs = jobJSON
-              jobText = buildJobList(defaultPage)
-            } else {
-              jobText += `<center><h3>No results.</h3></center>`
-              jobText += `<center><p>Please try again.</p></center>`
+      }
+
+      if (locationSelectionText == 'All Locations') {
+        locationSelectionText = ''
+      }
+
+      let categorySelectionText =
+        categorySelection.options[categorySelection.selectedIndex].text
+
+      if (categorySelectionText == 'All Categories') {
+        categorySelectionText = ''
+      }
+
+      let jobText = ''
+
+      // Build search URL + call the buildJobList method on JSON results if they are valid and displays jobs via 'results'
+      generateSearchResults()
+
+      async function generateSearchResults() {
+        // Makes sure city data is fetched prior to commencing method
+        const cityDelay = await fetch('https://geolocation-db.com/json/')
+
+        let webhook_url =
+          'https://ap-southeast-2.aws.webhooks.mongodb-realm.com/api/client/v2.0/app/jobsearchapp-wfuox/service/jobs/incoming_webhook/getJobs'
+
+        // Appends the relevant search terms to the webhook to access search data
+        let url =
+          webhook_url +
+          '?arg=' +
+          searchString +
+          '&location=' +
+          locationSelectionText +
+          '&category=' +
+          categorySelectionText
+
+        fetch(url)
+          .then(function (response) {
+            if (!response.ok) {
+              console.log(response)
+              jobText += `<center><h3>Status: ${response.status}</h3></center>`
+              if (response.json.length === 0)
+                jobText += `<center><p>Please enter a search term.</p></center>`
+              document.getElementById('results').innerHTML = jobText
+              throw Error(response.statusText)
             }
-          }
-          document.getElementById('results').innerHTML = jobText
-        })
-        .catch(function (error) {
-          console.log('Error: ', error)
-        })
-    }
-  }
+            return response.json()
+          })
+          .then(function (jobJSON) {
+            if (jobJSON['$undefined'] === true) {
+              console.log('No results fetched.')
+            } else {
+              console.log('Results fetched...')
+              if (jobJSON.length !== 0) {
+                jobText = ' jobs found.'
+                if (jobJSON.length == 1) {
+                  jobText = ' job found.'
+                }
+                console.log('Search results found: ' + jobJSON.length)
+                document.getElementById('resultsFound').innerHTML =
+                  jobJSON.length + jobText
+                jobs = jobJSON
+                jobText = buildJobList(defaultPage)
+              } else {
+                jobText += `<center><h3>No results.</h3></center>`
+                jobText += `<center><p>Please try again.</p></center>`
+              }
+            }
 
-  // Iterates through the passed jobs JSON file and builds individual job cards, appending them to jobText and organises them into pages
-  function buildJobList(currentPage) {
-    setURL(
-      searchString,
-      currentPage,
-      locationSelection.options[locationSelection.selectedIndex].text,
-      categorySelection.options[categorySelection.selectedIndex].text
-    )
-    document.body.scrollTop = 0
-    document.documentElement.scrollTop = 0
+            document.getElementById('results').innerHTML = jobText
 
-    let results = 10
-    let resultsMax = jobs.length
-
-    let pages = Math.floor(jobs.length / results)
-    let remainder = jobs.length % results
-
-    let i = currentPage * 10
-    if (jobs.length >= 10) {
-      resultsMax = i + results
-    }
-    if (remainder != 0 && pages != 0) {
-      pages += 1
-      if (currentPage == pages - 1) {
-        resultsMax = i + remainder
+            getModal(loadModal)
+            initPopover()
+          })
+          .catch(function (error) {
+            console.log('Error: ', error)
+          })
       }
     }
 
-    let j = 0
+    // Iterates through the passed jobs JSON file and builds individual job cards, appending them to jobText and organises them into pages
+    function buildJobList(currentPage) {
+      defaultPage = currentPage
+      setURL(
+        searchString,
+        defaultPage,
+        locationSelection.options[locationSelection.selectedIndex].text,
+        categorySelection.options[categorySelection.selectedIndex].text,
+        loadModal
+      )
+      document.body.scrollTop = 0
+      document.documentElement.scrollTop = 0
 
-    let jobText = ''
-    document.getElementById('pages').innerHTML = ''
+      let results = 10
+      let resultsMax = jobs.length
 
-    // List of tags which will be applied to each job listing if they contain the matching keyword
-    let tagDirectory = [
-      '.NET',
-      'JavaScript',
-      'React',
-      'Frontend',
-      'Angular',
-      'Backend',
-      'C#',
-      'AWS',
-      'Azure',
-      'Front End',
-      'Full Stack',
-      'Fullstack',
-      'Junior',
-      'Intern',
-      'Internship',
-      'TypeScript',
-      'Senior',
-      'Intermediate',
-      'Python',
-      'Graduate',
-      'Mobile',
-      'iOS',
-      'Android',
-    ]
+      let pages = Math.floor(jobs.length / results)
+      let remainder = jobs.length % results
 
-    for (j; j < pages; j++) {
-      if (j == currentPage) {
-        document.getElementById(
-          'pages'
-        ).innerHTML += `<button type="button" class="btn btn-primary me-md-1" disabled>${[
-          j + 1,
-        ]}</button>`
-      } else {
-        document.getElementById(
-          'pages'
-        ).innerHTML += `<button type="button" class="btn btn-primary me-md-1" onclick="buildJobList(${[
-          j,
-        ]})">${[j + 1]}</button>`
+      let i = currentPage * 10
+      if (jobs.length >= 10) {
+        resultsMax = i + results
       }
-    }
+      if (remainder != 0 && pages != 0) {
+        pages += 1
+        if (currentPage == pages - 1) {
+          resultsMax = i + remainder
+        }
+      }
+      let j = 0
+      let jobText = ''
+      document.getElementById('pages').innerHTML = ''
 
-    for (i; i < resultsMax; i++) {
-      jobText += `
+      // List of tags which will be applied to each job listing if they contain the matching keyword
+      let tagDirectory = [
+        '.NET',
+        'JavaScript',
+        'React',
+        'Frontend',
+        'Angular',
+        'Backend',
+        'C#',
+        'AWS',
+        'Azure',
+        'Front End',
+        'Full Stack',
+        'Fullstack',
+        'Junior',
+        'Intern',
+        'Internship',
+        'TypeScript',
+        'Senior',
+        'Intermediate',
+        'Python',
+        'Graduate',
+        'Mobile',
+        'iOS',
+        'Android',
+      ]
+
+      for (j; j < pages; j++) {
+        if (j == currentPage) {
+          document.getElementById(
+            'pages'
+          ).innerHTML += `<button type="button" class="btn btn-primary me-md-1" disabled>${[
+            j + 1,
+          ]}</button>`
+        } else {
+          document.getElementById(
+            'pages'
+          ).innerHTML += `<button type="button" class="btn btn-primary me-md-1" onclick="buildJobList(${[
+            j,
+          ]})">${[j + 1]}</button>`
+        }
+      }
+
+      for (i; i < resultsMax; i++) {
+        jobText += `
                   <div class="modal fade" id="thanksModal" tabindex="-1" aria-labelledby="thanksModalLabel" aria-hidden="true">
                   <div class="modal-dialog">
                       <div class="modal-content">
                       <div class="modal-header">
                           <h5 class="modal-title" id="thanksModalLabel">Thank you for reporting.</h5>
-                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" onclick="setModal('')"></button>
                       </div>
                       <div class="modal-body">
                           If we find this content is inappropriate, we will remove it.
                       </div>
                       <div class="modal-footer">
-                          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" onclick="setModal('')">Close</button>
                       </div>
                       </div>
                   </div>
                   </div>
 
               <div class="modal fade" id="modal${[
-                i,
-              ]}" tabindex="-1" aria-labelledby="applyModalLabel" aria-hidden="true">
+            i,
+          ]}" tabindex="-1" aria-labelledby="applyModalLabel" aria-hidden="true">
               <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
                   <div class="modal-content ">
                       <div class="modal-header">
                           <div class="fw-lighter" id="job-title"><p></p></div>
-                          <h5 class="modal-title" id="applyModalLabel"><div class="fw-lighter fs-6">${
-                            jobs[i].company
-                          }</div> ${jobs[i].jobTitle}</h5>
-                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                          <h5 class="modal-title" id="applyModalLabel"><div class="fw-lighter fs-6">${jobs[i].company
+          }</div> ${jobs[i].jobTitle}</h5>
+                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" onclick="setModal('')"></button>
                       </div>
                       <div class="modal-body">
                           <p>
                               ${jobs[i].summary}
                           </p>
-                          <div class="fw-light">Is this content inappropriate? <a onclick="report('A user', '${
-                            jobs[i]._id.$oid
-                          }, ${jobs[i].jobTitle}, ${jobs[i].company}, ${
-        jobs[i].summary
-      }: ${
-        jobs[i].link
-      }')" href="#" data-bs-dismiss="modal" data-bs-toggle="modal" data-bs-target="#thanksModal">Report</a></div>
+                          <div class="fw-light">Is this content inappropriate? <a onclick="report('A user', '${jobs[i]._id.$oid
+          }, ${jobs[i].jobTitle}, ${jobs[i].company}, ${jobs[i].summary
+          }: ${jobs[i].link
+          }')" href="#" data-bs-dismiss="modal" data-bs-toggle="modal" data-bs-target="#thanksModal">Report</a></div>
                       </div>
-                      <div class="modal-footer">
+                          <div class="modal-footer">
+                          <a onclick="copyClipboard()" tabindex="0" class="btn btn-outline-primary" role="button" data-bs-toggle="popover" data-bs-trigger="focus" data-bs-content="Copied to clipboard"><i class="far fa-copy"></i></a>
                           <button type="button" class="btn btn-outline-primary">♡</button>
-                          <a href="${
-                            jobs[i].link
-                          }"><button type="button" class="btn btn-primary">Apply</button></a>
+                          <a href="${jobs[i].link
+          }"><button type="button" class="btn btn-primary">Apply</button></a>
                       </div>
                   </div>
               </div>
@@ -316,132 +305,158 @@
               <li class="list-group-item d-flex justify-content-between align-items-start">
                 <div class="ms-2 me-auto" style="max-width: 70%;">
                   <div class="fs-6">${jobs[i].location}</div>
-                  <div class="fw-lighter" id="job-title">${
-                    jobs[i].company
-                  }</div>
+                  <div class="fw-lighter" id="job-title">${jobs[i].company
+          }</div>
                     <div class="fs-5">${jobs[i].jobTitle}</div>
-                    <div class="fs-6" style="max-width: 90%; overflow: hidden; max-height: 50px">${
-                      jobs[i].summary
-                    }</div>
+                    <div class="fs-6" style="max-width: 90%; overflow: hidden; max-height: 50px">${jobs[i].summary
+          }</div>
                     `
 
-      // Assigns each job tags if keywords found in tagDirectory can be matched job's against title & summary
-      for (let tagIndex = 0; tagIndex < tagDirectory.length; tagIndex++) {
-        if (
-          (
-            jobs[i].jobTitle.toLowerCase() || jobs[i].summary.toLowerCase()
-          ).includes(tagDirectory[tagIndex].toLowerCase())
-        ) {
-          jobText += `
-          <button style="border-radius: 16px; font-size: 0.9em" type="button" class="btn btn-primary btn-sm py-0" onclick="window.location='${urlBuilder(
-            tagDirectory[tagIndex],
-            0
-          )}';">${tagDirectory[tagIndex]}</button> `
+        // Assigns each job tags if keywords found in tagDirectory can be matched job's against title & summary
+        for (let tagIndex = 0; tagIndex < tagDirectory.length; tagIndex++) {
+          if (
+            (
+              jobs[i].jobTitle.toLowerCase() || jobs[i].summary.toLowerCase()
+            ).includes(tagDirectory[tagIndex].toLowerCase())
+          ) {
+            jobText += `
+          <span class="badge rounded-pill bg-primary">${tagDirectory[tagIndex]}</span> `
+          }
         }
-      }
 
-      jobText += `
+        jobText += `
                 </div>
                   <div class="mx-2 my-auto">
                     <button type="button" class="btn btn-outline-primary">♡</button>
                     <button type="button" class="btn btn-primary" data-bs-toggle="modal"
-                    data-bs-target="#modal${[i]}">Apply</button>
+                    data-bs-target="#modal${[i]}" onclick="setModal('modal'+${[i]})">Apply</button>
                   </div>
                 </div>
               </li>
             </ol>
           </div>
           `
+      }
+      document.getElementById('results').innerHTML = jobText
+      initPopover()
+      return jobText
     }
-    document.getElementById('results').innerHTML = jobText
-    return jobText
-  }
 
-  async function promptReport() {
-    let dialogue = ''
-  }
-
-  /**
-   * Send POST request to server with report data
-   */
-  async function report(user, url) {
-    const data = { user, url }
-    console.log(url)
-    const options = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(data),
+    async function promptReport() {
+      let dialogue = ''
     }
-    const response = await fetch('/report', options)
-  }
 
-  //Maintains URL
-  function setURL(search, page, location, category) {
-    page += 1
-    const urlParams = new URLSearchParams(
-      '?search=' +
+    /**
+     * Send POST request to server with report data
+     */
+    async function report(user, url) {
+      const data = { user, url }
+      console.log(url)
+      const options = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      }
+      const response = await fetch('/report', options)
+    }
+
+    //Maintains URL
+    function setURL(search, page, location, category, modal) {
+      page += 1
+      const urlParams = new URLSearchParams(
+        '?search=' +
         search +
         '&page=' +
         page +
         '&location=' +
         location +
         '&category=' +
-        category
-    )
-    window.history.replaceState(
-      null,
-      null,
-      window.location.pathname + '?' + urlParams
-    )
+        category +
+        '&modal=' +
+        modal
+      )
+      window.history.replaceState(
+        null,
+        null,
+        window.location.pathname + '?' + urlParams
+      )
 
-    for (const [key, value] of urlParams) {
-      console.log(`${key}:${value}`)
-    }
-  }
-
-  function checkURL() {
-    const urlParams = new URLSearchParams(location.search)
-
-    for (const [key, value] of urlParams) {
-      console.log(`${key}:${value}`)
+      for (const [key, value] of urlParams) {
+        console.log(`${key}:${value}`)
+      }
     }
 
-    if (urlParams.has('search')) {
-      if (urlParams.has('page')) {
-        pageNo = urlParams.get('page') - 1
-        defaultPage = pageNo
+    function checkURL() {
+      const urlParams = new URLSearchParams(location.search)
+
+      for (const [key, value] of urlParams) {
+        console.log(`${key}:${value}`)
       }
-      if (urlParams.has('location')) {
-        document.getElementById('location-selection').value = urlParams.get(
-          'location'
-        )
+
+      if (urlParams.has('search')) {
+        if (urlParams.has('page')) {
+          defaultPage = urlParams.get('page') - 1
+        }
+        if (urlParams.has('location')) {
+          document.getElementById('location-selection').value = urlParams.get(
+            'location'
+          )
+        }
+        if (urlParams.has('category')) {
+          document.getElementById('category-selection').value = urlParams.get(
+            'category'
+          )
+        }
+        if (urlParams.has('modal')) {
+          loadModal = urlParams.get('modal')
+          console.log('testing ' +  loadModal)
+        }
+        document.getElementById('userInput').value = urlParams.get('search')
+        userAction()
       }
-      if (urlParams.has('category')) {
-        document.getElementById('category-selection').value = urlParams.get(
-          'category'
-        )
-      }
-      document.getElementById('userInput').value = urlParams.get('search')
-      userAction()
     }
-  }
 
-  function urlBuilder(search) {
-    let urlParams =
-      'jobsearch?search=' +
-      search +
-      '&page=' +
-      1 +
-      '&location=' +
-      document.getElementById('location-selection').value +
-      '&category=' +
-      document.getElementById('category-selection').value
+    function getModal(mod) {
+      if (loadModal != 'undefined' && loadModal != '' && loadModal != null) {
+        console.log('loaded' + mod)
+        var myModal = new bootstrap.Modal(document.getElementById(mod), {
+          keyboard: false
+        })
+        myModal.show()
+        
+      }
+    }
 
-    // TEMP: RETURNING INCLUDES PORT UNTIL HOSTED
-    return 'http://' + window.location.hostname + ':3000/' + urlParams
-  }
-</script>
+    function setModal(modal) {
+      loadModal = modal
+      console.log('the test ' + defaultPage)
+      setURL(
+        searchString,
+        defaultPage,
+        locationSelection.options[locationSelection.selectedIndex].text,
+        categorySelection.options[categorySelection.selectedIndex].text,
+        loadModal
+      )
+      buildJobList(defaultPage)
+    }
 
-<%- include('partials/footer'); -%>
+    function copyClipboard() {
+      navigator.clipboard.writeText(window.location.href)
+    }
+
+    //Enables popovers (for the copy to clipboard button)
+    function initPopover() {
+      var popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'))
+      var popoverList = popoverTriggerList.map(function (popoverTriggerEl) {
+        return new bootstrap.Popover(popoverTriggerEl)
+      })
+    }
+
+
+
+
+  </script>
+
+  <%- include('partials/footer'); -%>

--- a/website/myapp/views/partials/header.ejs
+++ b/website/myapp/views/partials/header.ejs
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="UTF-8" />
     <title>JobSpy</title>
 
     <!-- Bootstrap CSS/JS -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="//use.fontawesome.com/releases/v5.0.7/css/all.css">
+    
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js"
@@ -30,7 +32,7 @@
         <div class="container-fluid">
             <a class="navbar-brand" href="/">
                 <img src="JSLogo.png" alt="Home" height="32" class="d-inline-block align-text-top">
-              </a>
+            </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarTogglerDemo02"
                 aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
There's a clipboard button on each job modal on the jobsearch page which copies the current job listing url. Opening the url redirects to the same search, same page and same job modal. Also fixed bugs with the url system.

I changed the icon library in the head so the about-us page has missing icons - need to fix later.